### PR TITLE
fix bug in copy function

### DIFF
--- a/src/components/CopyButton.jsx
+++ b/src/components/CopyButton.jsx
@@ -3,8 +3,11 @@ import React, { useState } from 'react';
 const CopyButton = ({ textToCopy }) => {
   const [copyButtonText, setCopyButtonText] = useState('Copy Lyrics');
 
+
+
   const copyToClipboard = () => {
-    navigator.clipboard.writeText(textToCopy);
+    const formattedLyrics = textToCopy.replace(/\n/g, '\n\n');
+    navigator.clipboard.writeText(formattedLyrics);
     setCopyButtonText('Copied');
 
     setTimeout(() => {


### PR DESCRIPTION
Copy function on search page is not picking the text formatting

Steps to reproduce
1. Click search
2. Click copy 
3. Returns unformatted lyrics

Expected behaviour
Copied text should retain double line spacing